### PR TITLE
[1.1.1]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ts-appconfig
 
+## [1.1.1]
+
+### Fixes
+
 ## [1.1.0]
 
 ### Additions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [1.1.1]
 
 ### Fixes
+- [Issue #8] .env file variables which are not assigned a value should be skipped
 - [Issue #7] Readme imports are relative instead of from npm package
 
 ## [1.1.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [1.1.1]
 
 ### Fixes
+- [Issue #7] Readme imports are relative instead of from npm package
 
 ## [1.1.0]
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Create a file where you will declare your environment variable schema:
 
 `src/environment.ts`
 ```typescript
-import { AppConfig, configure } from '../src';
+import { AppConfig, configure } from 'ts-appconfig';
 
 export class Environment extends AppConfig {
 	readonly APP_TITLE: string = '';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "ts-appconfig",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "ts-appconfig",
-			"version": "1.1.0",
+			"version": "1.1.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@istanbuljs/nyc-config-typescript": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "ts-appconfig",
 	"private": "true",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"ts-project-version": "2.0.0",
 	"description": "Strongly Typed DotENV - Environment Variables",
 	"scripts": {

--- a/src/parser/parse.ts
+++ b/src/parser/parse.ts
@@ -30,7 +30,7 @@ export function parseLines(
 		// Parse the line
 		const parts = line.match(lineRegex);
 
-		if (parts === null) {
+		if (parts === null || !parts.length) {
 			if (options.skipUnknownLines) {
 				continue;
 			}
@@ -49,6 +49,11 @@ export function parseLines(
 		}
 
 		// Read val
+		if (!(2 in parts) || !parts[2]) {
+			// Value is undefined, ignore
+			continue;
+		}
+
 		const val = stripComment(parts[2]);
 
 		// Assign value

--- a/test/spec/parser/parse.spec.ts
+++ b/test/spec/parser/parse.spec.ts
@@ -27,6 +27,13 @@ describe('parser/parse', () => {
 		expect(Object.keys(lines).length).toBe(0);
 	});
 
+	it('ignores lines with no assignment', () => {
+		const line = 'APP_TEST=';
+		const lines: RawKeyValues = parseLines([ line ], {});
+
+		expect(lines.APP_TEST).toBe(undefined);
+	});
+
 	it('skips unparsable lines when skipUnknownLines is true', () => {
 		const line = 'zxcv';
 		const lines: RawKeyValues = parseLines([ line ], {


### PR DESCRIPTION
### Fixes
- [Issue #8] .env file variables which are not assigned a value should be skipped
- [Issue #7] Readme imports are relative instead of from npm package